### PR TITLE
Use dyn instead of implement Car for all types

### DIFF
--- a/src/carlib/car.rs
+++ b/src/carlib/car.rs
@@ -12,3 +12,10 @@ pub trait Car {
     fn get_name(&self) -> String;
     // The trait itself however cannot have any fields.
 }
+
+//trait to make easy for an "object" to return a refernece to itself that impl
+//Car
+pub trait CarInheritance {
+    fn as_car(&self) -> &dyn Car;
+    fn as_mut_car(&mut self) -> &mut dyn Car;
+}

--- a/src/carlib/car_impl.rs
+++ b/src/carlib/car_impl.rs
@@ -1,5 +1,5 @@
 // Import the Car trait
-use crate::carlib::car::Car;
+use crate::carlib::car::{Car, CarInheritance};
 
 // So we define a struct that contains the fields
 // such as speed and acceleration.
@@ -9,6 +9,15 @@ pub struct CarImpl {
     // A car can be named anything anytime
     // So no physics applies. Thus I make it public.
     pub name: String, // public field
+}
+
+impl CarInheritance for CarImpl {
+    fn as_car(&self) -> &dyn Car {
+        self
+    }
+    fn as_mut_car(&mut self) -> &mut dyn Car {
+        self
+    }
 }
 
 // If we do not want to expose CarImpl to the outside,
@@ -48,7 +57,6 @@ impl Car for CarImpl {
         // We can access the private fields of the struct
         self.speed += self.acceleration * duration;
     }
-
     fn brake(&mut self, force: f64) {
         self.speed -= force * self.speed;
         if self.speed < 0.0 {
@@ -57,14 +65,12 @@ impl Car for CarImpl {
             self.speed = 0.0;
         }
     }
-
     fn get_speed(&self) -> f64 {
         // Not entirely sure whether I need this .clone().
         // In any case I do not want to return a reference
         // or even move it.
         self.speed.clone()
     }
-
     fn get_name(&self) -> String {
         self.name.clone()
     }

--- a/src/carlib/family_car.rs
+++ b/src/carlib/family_car.rs
@@ -1,4 +1,4 @@
-use crate::carlib::car::Car;
+use crate::carlib::car::{Car, CarInheritance};
 use crate::carlib::car_impl::CarImpl;
 
 // Let's try a different approach with the family car.
@@ -18,16 +18,11 @@ impl Familycar {
     }
 }
 
-// Here we implement the Car trait for the Familycar.
-// This time we use the `delegate!` macro.
-// With this macro we can get rid of quite some boilerplate code.
-impl Car for Familycar {
-    delegate::delegate! {
-        to self.imp {
-            fn accelerate(&mut self, duration: f64);
-            fn brake(&mut self, force: f64);
-            fn get_speed(&self) -> f64;
-            fn get_name(&self) -> String;
-        }
+impl CarInheritance for Familycar {
+    fn as_car(&self) -> &dyn Car {
+        &self.imp
+    }
+    fn as_mut_car(&mut self) -> &mut dyn Car {
+        &mut self.imp
     }
 }

--- a/src/carlib/sports_car.rs
+++ b/src/carlib/sports_car.rs
@@ -1,4 +1,4 @@
-use crate::carlib::car::Car;
+use crate::carlib::car::{Car, CarInheritance};
 use crate::carlib::car_impl::CarImpl;
 
 // Rust seems to encourage composition over direct inheritance.
@@ -27,23 +27,11 @@ impl Sportscar {
         return obj;
     }
 }
-
-// Here we implement the Car trait for the Sportscar.
-// Easy enough boilerplate code. But quite some boilerplate still.
-impl Car for Sportscar {
-    fn accelerate(&mut self, duration: f64) {
-        self.imp.accelerate(duration);
+impl CarInheritance for Sportscar {
+    fn as_car(&self) -> &dyn Car {
+        &self.imp
     }
-
-    fn brake(&mut self, force: f64) {
-        self.imp.brake(force);
-    }
-
-    fn get_speed(&self) -> f64 {
-        self.imp.get_speed()
-    }
-
-    fn get_name(&self) -> String {
-        self.imp.get_name()
+    fn as_mut_car(&mut self) -> &mut dyn Car {
+        &mut self.imp
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod carlib;
-use crate::carlib::car::Car;
+
+use crate::carlib::car::{Car, CarInheritance};
 use crate::carlib::family_car::Familycar;
 use crate::carlib::sports_car::Sportscar;
 
@@ -18,7 +19,7 @@ fn print_car_speed(car: &dyn Car) {
 //     println!("{} travels at {} km/h", car.name, car.get_speed());
 // }
 
-fn print_car(car: &Box<dyn Car>) {
+fn print_car(car: &dyn Car) {
     println!("{} travels at {} km/h", car.get_name(), car.get_speed());
 }
 
@@ -54,22 +55,24 @@ fn main() {
     // That is cool and all but what about the sports car?
 
     let mut flizzr = Sportscar::new_named("Flizzr".to_string());
+    let flizzr = flizzr.as_mut_car();
     // Here the `imp` can not be accessed. It is private.
     //flizzr.imp.name = "Flizzr".to_string();
     flizzr.accelerate(100.0);
-    print_car_speed(&flizzr);
+    print_car_speed(flizzr);
 
     // let c = carlib::Car::new(); // This does not compile. Car is an interface.
     // let c = <dyn carlib::Car>::new(); // new() does not exist. So this does not compile either.
 
     let mut tuktuk = Familycar::new();
     tuktuk.imp.name = "Tuk-tuk".to_string();
+    let tuktuk = tuktuk.as_mut_car();
 
     tuktuk.accelerate(100.0);
-    print_car_speed(&tuktuk);
+    print_car_speed(tuktuk);
 
     // Now lets create a vector of cars.
-    let mut cars: Vec<Box<dyn Car>> = Vec::new();
+    let mut cars: Vec<Box<dyn CarInheritance>> = Vec::new();
     cars.push(Box::new(Sportscar::new_named(
         "SpeedyMcSpeedface".to_string(),
     )));
@@ -78,7 +81,7 @@ fn main() {
 
     // Iterate over all cars in the vector and accelerate them for 200 seconds.
     for car in cars.iter_mut() {
-        car.accelerate(200.0);
-        print_car(car);
+        car.as_mut_car().accelerate(200.0);
+        print_car(car.as_car());
     }
 }


### PR DESCRIPTION
I discourage you programing rust thinking exclusively in terms of Object-Oritentation.

But here something cool that you can do.